### PR TITLE
Monitoring Stack

### DIFF
--- a/apps/monitoring/.gitignore
+++ b/apps/monitoring/.gitignore
@@ -1,0 +1,1 @@
+monitoring/

--- a/apps/monitoring/flux-kustomization-config.yaml
+++ b/apps/monitoring/flux-kustomization-config.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+kind: Kustomization
+metadata:
+  name: monitoring-config
+  namespace: flux-system
+spec:
+  interval: 1h0m0s
+  path: ./manifests/monitoring/monitoring-config
+  prune: true
+  dependsOn:
+    - name: monitoring-stack
+  sourceRef:
+    kind: GitRepository
+    name: monitoring
+

--- a/apps/monitoring/flux-kustomization.yaml
+++ b/apps/monitoring/flux-kustomization.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+kind: Kustomization
+metadata:
+  name: monitoring-stack
+  namespace: flux-system
+spec:
+  healthChecks:
+  - kind: Deployment
+    name: kube-prometheus-stack-operator
+    namespace: monitoring
+  - kind: Deployment
+    name: kube-prometheus-stack-grafana
+    namespace: monitoring
+  interval: 1h0m0s
+  path: ./manifests/monitoring/kube-prometheus-stack
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: monitoring
+  timeout: 2m0s
+

--- a/apps/monitoring/kustomization.yaml
+++ b/apps/monitoring/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- flux-kustomization-config.yaml
+- flux-kustomization.yaml
+- source.yaml

--- a/apps/monitoring/source.yaml
+++ b/apps/monitoring/source.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta1
+kind: GitRepository
+metadata:
+  name: monitoring
+  namespace: flux-system
+spec:
+  interval: 30m0s
+  ref:
+    branch: monitoring
+  url: https://github.com/kingdonb/flux2

--- a/clusters/moo-cluster/certificates/flux-kustomization.yaml
+++ b/clusters/moo-cluster/certificates/flux-kustomization.yaml
@@ -19,4 +19,4 @@ spec:
     - name: 20-my-secrets
   prune: false
   wait: false
- #suspend: false
+  suspend: true

--- a/clusters/moo-cluster/flux-system/flux-sync.yaml
+++ b/clusters/moo-cluster/flux-system/flux-sync.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 10m0s
   ref:
-    branch: staging
+    branch: monitoring
   secretRef:
     name: flux-system
   url: ssh://git@github.com/kingdonb/bootstrap-repo

--- a/clusters/moo-cluster/flux-system/flux-sync.yaml
+++ b/clusters/moo-cluster/flux-system/flux-sync.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 10m0s
   ref:
-    branch: monitoring
+    branch: staging
   secretRef:
     name: flux-system
   url: ssh://git@github.com/kingdonb/bootstrap-repo

--- a/clusters/moo-cluster/hephy/flux-kustomization.yaml
+++ b/clusters/moo-cluster/hephy/flux-kustomization.yaml
@@ -12,7 +12,7 @@ spec:
     name: flux-sync
   path: ./apps/hephy
   dependsOn:
-    - name: 11-certificates
+  # - name: 11-certificates
     - name: 12-persistence
   prune: true
   wait: false

--- a/clusters/moo-cluster/keycloak/flux-kustomization.yaml
+++ b/clusters/moo-cluster/keycloak/flux-kustomization.yaml
@@ -12,7 +12,7 @@ spec:
     name: flux-system
   path: ./apps/keycloak
   dependsOn:
-    - name: 11-certificates
+  # - name: 11-certificates
     - name: 20-my-secrets
     - name: 30-ingress-nginx
   prune: true

--- a/clusters/moo-cluster/kube-oidc-proxy/flux-kustomization.yaml
+++ b/clusters/moo-cluster/kube-oidc-proxy/flux-kustomization.yaml
@@ -12,7 +12,7 @@ spec:
     name: flux-system
   path: ./apps/kube-oidc-proxy
   dependsOn:
-    - name: 11-certificates
+  # - name: 11-certificates
     - name: 20-my-secrets
     - name: 30-ingress-nginx
   prune: true

--- a/clusters/moo-cluster/kustomization.yaml
+++ b/clusters/moo-cluster/kustomization.yaml
@@ -25,3 +25,4 @@ resources:
 - kube-oidc-proxy
 - persistence
 - certificates
+- monitoring

--- a/clusters/moo-cluster/monitoring/flux-kustomization.yaml
+++ b/clusters/moo-cluster/monitoring/flux-kustomization.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+kind: Kustomization
+metadata:
+  name: 80-monitoring
+  namespace: flux-system
+spec:
+  interval: 10m0s
+  retryInterval: 6m0s
+  timeout: 4m0s
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./apps/monitoring
+  prune: false
+  wait: false
+  suspend: false

--- a/clusters/moo-cluster/monitoring/kustomization.yaml
+++ b/clusters/moo-cluster/monitoring/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- flux-kustomization.yaml

--- a/clusters/moo-cluster/openvpn-as/flux-kustomization.yaml
+++ b/clusters/moo-cluster/openvpn-as/flux-kustomization.yaml
@@ -12,7 +12,7 @@ spec:
     name: flux-system
   path: ./apps/openvpn
   dependsOn:
-    - name: 11-certificates
+  # - name: 11-certificates
     - name: 12-persistence
     - name: 20-my-secrets
     - name: 30-ingress-nginx


### PR DESCRIPTION
There is a dashboard at: http://kube-prometheus-stack-grafana.monitoring.svc.cluster.local/d/nginx/nginx-ingress-controller?orgId=1&refresh=5s which shows our certificates are all good for at least 10 weeks.

(I have added the NGINX dashboard at: [branch: monitoring] https://github.com/kingdonb/flux2/commit/a921ab3de5bdcfe0109b46e564613847c91d44c2, https://github.com/kingdonb/flux2/commit/453f150d64b0550398c1199f800f369824595819, https://github.com/kingdonb/flux2/commit/0863655ec253c4266e1fbe2ccb31a9b26a479b8e)