### PR TITLE
Remove validation from manifest

### DIFF
--- a/clusters/moo-cluster/ingress-nginx/flux-kustomization.yaml
+++ b/clusters/moo-cluster/ingress-nginx/flux-kustomization.yaml
@@ -15,7 +15,6 @@ spec:
     - name: 29-metallb
   prune: true
   wait: true
-  validation: client
   healthChecks:
     - apiVersion: apps/v1
       kind: Deployment

--- a/clusters/production/apps.yaml
+++ b/clusters/production/apps.yaml
@@ -14,4 +14,4 @@ spec:
     name: flux-system
   path: ./apps/production
   prune: true
-  validation: client
+  wait: true

--- a/clusters/production/infrastructure.yaml
+++ b/clusters/production/infrastructure.yaml
@@ -12,4 +12,4 @@ spec:
     name: flux-system
   path: ./infrastructure
   prune: true
-  validation: client
+  wait: true

--- a/clusters/staging/apps.yaml
+++ b/clusters/staging/apps.yaml
@@ -14,4 +14,4 @@ spec:
     name: flux-system
   path: ./apps/staging
   prune: true
-  validation: client
+  wait: true

--- a/clusters/staging/infrastructure.yaml
+++ b/clusters/staging/infrastructure.yaml
@@ -12,4 +12,4 @@ spec:
     name: flux-system
   path: ./infrastructure
   prune: true
-  validation: client
+  wait: true


### PR DESCRIPTION
doesn't really disable validation, since Flux 0.18 validation is always
on with Server-Side Apply.

enable "wait" so dependsOn-through works as expected, if infrastructure
is ever anything more than just some CRDs.