### PR TITLE
Harbor cert-manager

### DIFF
--- a/apps/routers/harbor-certmanager/harbor-img-ingressroute.yaml
+++ b/apps/routers/harbor-certmanager/harbor-img-ingressroute.yaml
@@ -1,0 +1,33 @@
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: img
+  namespace: traefik-staging
+spec:
+  entryPoints:
+  - web
+  routes:
+  - kind: Rule
+    match: Host(`img.hephy.pro`)
+    services:
+    - kind: Service
+      name: img-public-challenge
+      namespace: traefik-staging
+      port: 80
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRouteTCP
+metadata:
+  name: img
+  namespace: traefik-staging
+spec:
+  entryPoints:
+    - websecure
+  routes:
+  - match: HostSNI(`img.hephy.pro`)
+    services:
+    - name: img-public-challenge
+      namespace: traefik-staging
+      port: 443
+  tls:
+    passthrough: true

--- a/apps/routers/harbor-certmanager/img-service-endpoints.yaml
+++ b/apps/routers/harbor-certmanager/img-service-endpoints.yaml
@@ -1,0 +1,31 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: img-public-challenge
+  namespace: traefik-staging
+spec:
+  ports:
+    - name: img-not-found
+      protocol: TCP
+      port: 443
+      targetPort: 443
+      nodePort: 0
+    - name: img-http-challenge
+      protocol: TCP
+      port: 80
+      targetPort: 80
+      nodePort: 0
+---
+kind: Endpoints
+apiVersion: v1
+metadata:
+  name: img-public-challenge
+  namespace: traefik-staging
+subsets:
+- addresses:
+  - ip: 10.17.12.202
+  ports:
+  - port: 443
+    name: img-not-found
+  - port: 80
+    name: img-http-challenge


### PR DESCRIPTION
Add IngressRoutes for Harbor to perform HTTP-01 certificate verification through Traefik Proxy

Only the HTTP-01 verification is passed through to the public ingress

There is no way for public traffic to reach Harbor at https://img.hephy.pro (which is created as an `internal` IngressClass)