### PR TITLE
Fixup harbor

### DIFF
--- a/persistence/harbor/harbor-chartmuseum-pv.yaml
+++ b/persistence/harbor/harbor-chartmuseum-pv.yaml
@@ -3,14 +3,14 @@ kind: PersistentVolume
 metadata:
   annotations:
     pv.kubernetes.io/provisioned-by: rancher.io/local-path
-  name: pvc-deef07a4-73d8-4fe4-95d1-1ac6c21da40b
+  name: pvc-deef07a4-73d8-4fe4-95d1-1ac6c21da40a
 spec:
   accessModes:
   - ReadWriteOnce
   capacity:
     storage: 5Gi
   hostPath:
-    path: /opt/local-path-provisioner/pvc-deef07a4-73d8-4fe4-95d1-1ac6c21da40b_harbor_harbor-chartmuseum
+    path: /opt/local-path-provisioner/pvc-deef07a4-73d8-4fe4-95d1-1ac6c21da40a_harbor_harbor-chartmuseum
     type: DirectoryOrCreate
   nodeAffinity:
     required:

--- a/persistence/harbor/harbor-chartmuseum.yaml
+++ b/persistence/harbor/harbor-chartmuseum.yaml
@@ -26,4 +26,4 @@ spec:
     requests:
       storage: 5Gi
   storageClassName: local-path
-  volumeName: pvc-deef07a4-73d8-4fe4-95d1-1ac6c21da40b
+  volumeName: pvc-deef07a4-73d8-4fe4-95d1-1ac6c21da40a

--- a/persistence/harbor/harbor-db-postgres-pv.yaml
+++ b/persistence/harbor/harbor-db-postgres-pv.yaml
@@ -3,14 +3,14 @@ kind: PersistentVolume
 metadata:
   annotations:
     pv.kubernetes.io/provisioned-by: rancher.io/local-path
-  name: pvc-6ec6cb5c-6e7d-4d20-bb86-8e50046d3f39
+  name: pvc-6ec6cb5c-6e7d-4d20-bb86-8e50046d3f38
 spec:
   accessModes:
   - ReadWriteOnce
   capacity:
     storage: 1Gi
   hostPath:
-    path: /opt/local-path-provisioner/pvc-6ec6cb5c-6e7d-4d20-bb86-8e50046d3f39_harbor_database-data-harbor-database-0
+    path: /opt/local-path-provisioner/pvc-6ec6cb5c-6e7d-4d20-bb86-8e50046d3f38_harbor_database-data-harbor-database-0
     type: DirectoryOrCreate
   nodeAffinity:
     required:

--- a/persistence/harbor/harbor-db-postgres.yaml
+++ b/persistence/harbor/harbor-db-postgres.yaml
@@ -20,4 +20,4 @@ spec:
     requests:
       storage: 1Gi
   storageClassName: local-path
-  volumeName: pvc-6ec6cb5c-6e7d-4d20-bb86-8e50046d3f39
+  volumeName: pvc-6ec6cb5c-6e7d-4d20-bb86-8e50046d3f38

--- a/persistence/harbor/harbor-jobservice-pv.yaml
+++ b/persistence/harbor/harbor-jobservice-pv.yaml
@@ -3,14 +3,14 @@ kind: PersistentVolume
 metadata:
   annotations:
     pv.kubernetes.io/provisioned-by: rancher.io/local-path
-  name: pvc-7f0f4586-d250-40b6-b149-758ba9c0c8a0
+  name: pvc-7f0f4586-d250-40b6-b149-758ba9c0c8a9
 spec:
   accessModes:
   - ReadWriteOnce
   capacity:
     storage: 1Gi
   hostPath:
-    path: /opt/local-path-provisioner/pvc-7f0f4586-d250-40b6-b149-758ba9c0c8a0_harbor_harbor-jobservice
+    path: /opt/local-path-provisioner/pvc-7f0f4586-d250-40b6-b149-758ba9c0c8a9_harbor_harbor-jobservice
     type: DirectoryOrCreate
   nodeAffinity:
     required:

--- a/persistence/harbor/harbor-jobservice.yaml
+++ b/persistence/harbor/harbor-jobservice.yaml
@@ -26,4 +26,4 @@ spec:
     requests:
       storage: 1Gi
   storageClassName: local-path
-  volumeName: pvc-7f0f4586-d250-40b6-b149-758ba9c0c8a0
+  volumeName: pvc-7f0f4586-d250-40b6-b149-758ba9c0c8a9

--- a/persistence/harbor/harbor-redis-pv.yaml
+++ b/persistence/harbor/harbor-redis-pv.yaml
@@ -3,14 +3,14 @@ kind: PersistentVolume
 metadata:
   annotations:
     pv.kubernetes.io/provisioned-by: rancher.io/local-path
-  name: pvc-78670a3b-c0ea-4130-9740-ae48eec43bbe
+  name: pvc-78670a3b-c0ea-4130-9740-ae48eec43bbd
 spec:
   accessModes:
   - ReadWriteOnce
   capacity:
     storage: 1Gi
   hostPath:
-    path: /opt/local-path-provisioner/pvc-78670a3b-c0ea-4130-9740-ae48eec43bbe_harbor_data-harbor-redis-0
+    path: /opt/local-path-provisioner/pvc-78670a3b-c0ea-4130-9740-ae48eec43bbd_harbor_data-harbor-redis-0
     type: DirectoryOrCreate
   nodeAffinity:
     required:

--- a/persistence/harbor/harbor-redis.yaml
+++ b/persistence/harbor/harbor-redis.yaml
@@ -20,4 +20,4 @@ spec:
     requests:
       storage: 1Gi
   storageClassName: local-path
-  volumeName: pvc-78670a3b-c0ea-4130-9740-ae48eec43bbe
+  volumeName: pvc-78670a3b-c0ea-4130-9740-ae48eec43bbd

--- a/persistence/harbor/harbor-registry-pv.yaml
+++ b/persistence/harbor/harbor-registry-pv.yaml
@@ -3,14 +3,14 @@ kind: PersistentVolume
 metadata:
   annotations:
     pv.kubernetes.io/provisioned-by: rancher.io/local-path
-  name: pvc-f6c57a73-91d5-4bac-b7a2-0bd3d11bec17
+  name: pvc-f6c57a73-91d5-4bac-b7a2-0bd3d11bec16
 spec:
   accessModes:
   - ReadWriteOnce
   capacity:
     storage: 5Gi
   hostPath:
-    path: /opt/local-path-provisioner/pvc-f6c57a73-91d5-4bac-b7a2-0bd3d11bec17_harbor_harbor-registry
+    path: /opt/local-path-provisioner/pvc-f6c57a73-91d5-4bac-b7a2-0bd3d11bec16_harbor_harbor-registry
     type: DirectoryOrCreate
   nodeAffinity:
     required:

--- a/persistence/harbor/harbor-registry.yaml
+++ b/persistence/harbor/harbor-registry.yaml
@@ -26,4 +26,4 @@ spec:
     requests:
       storage: 5Gi
   storageClassName: local-path
-  volumeName: pvc-f6c57a73-91d5-4bac-b7a2-0bd3d11bec17
+  volumeName: pvc-f6c57a73-91d5-4bac-b7a2-0bd3d11bec16

--- a/persistence/harbor/harbor-trivy-pv.yaml
+++ b/persistence/harbor/harbor-trivy-pv.yaml
@@ -3,14 +3,14 @@ kind: PersistentVolume
 metadata:
   annotations:
     pv.kubernetes.io/provisioned-by: rancher.io/local-path
-  name: pvc-e0215d50-9977-48ea-8e36-29e8b60e5621
+  name: pvc-e0215d50-9977-48ea-8e36-29e8b60e5620
 spec:
   accessModes:
   - ReadWriteOnce
   capacity:
     storage: 5Gi
   hostPath:
-    path: /opt/local-path-provisioner/pvc-e0215d50-9977-48ea-8e36-29e8b60e5621_harbor_data-harbor-trivy-0
+    path: /opt/local-path-provisioner/pvc-e0215d50-9977-48ea-8e36-29e8b60e5620_harbor_data-harbor-trivy-0
     type: DirectoryOrCreate
   nodeAffinity:
     required:

--- a/persistence/harbor/harbor-trivy.yaml
+++ b/persistence/harbor/harbor-trivy.yaml
@@ -20,4 +20,4 @@ spec:
     requests:
       storage: 5Gi
   storageClassName: local-path
-  volumeName: pvc-e0215d50-9977-48ea-8e36-29e8b60e5621
+  volumeName: pvc-e0215d50-9977-48ea-8e36-29e8b60e5620


### PR DESCRIPTION
Harbor is broken because for some reason chartmuseum is serving up 500s for everything

IDK why that is, but I couldn't care any less about chartmuseum than I do today because we are testing the new OCI charts 👍 just remove chartmuseum for today

(Our old persistent volumes didn't really get corrupted, this was just a bug that we experienced when upgrading Harbor)