### PR TITLE
commits.to ingressroute and service endpoint (prod)

### DIFF
--- a/apps/routers/commits-to-prod/commits-to-ingressroute.yaml
+++ b/apps/routers/commits-to-prod/commits-to-ingressroute.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRouteTCP
+metadata:
+  name: commits-to
+  namespace: traefik-staging
+spec:
+  entryPoints:
+    - websecure
+  routes:
+  - match: HostSNI(`commits.to`,`giovanni.commits.to`,`nwinter.commits.to`,`patrick.commits.to`,`thameera.commits.to`,`madge.commits.to`,`xenocid.commits.to`,`alok.commits.to`,`luke.commits.to`,`eugeniobruno.commits.to`,`arti.commits.to`,`brian.commits.to`,`michael.commits.to`,`chris.commits.to`,`forrest.commits.to`,`byorgey.commits.to`,`az.commits.to`,`sergii.commits.to`,`kim.commits.to`,`edyson.commits.to`,`bee.commits.to`,`max.commits.to`,`kevin.commits.to`,`philip.commits.to`,`alex.commits.to`,`aian.commits.to`,`mbork.commits.to`,`shanaqui.commits.to`,`martin.commits.to`,`cole.commits.to`,`dan.commits.to`,`alys.commits.to`,`clive.commits.to`,`dreev.commits.to`,`jordan.commits.to`,`clarissa.commits.to`,`mary.commits.to`,`echodaniel.commits.to`,`adam.commits.to`,`elviejo79.commits.to`,`jade.commits.to`,`jay.commits.to`,`mike.commits.to`,`kb.commits.to`,`nick.commits.to`)
+    services:
+    - name: commits-to
+      namespace: traefik-staging
+      port: 443
+  tls:
+    passthrough: true

--- a/apps/routers/commits-to-prod/commits-to-service-endpoints.yaml
+++ b/apps/routers/commits-to-prod/commits-to-service-endpoints.yaml
@@ -1,0 +1,24 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: commits-to
+  namespace: traefik-staging
+spec:
+  ports:
+    - name: k8s-https
+      protocol: TCP
+      port: 443
+      targetPort: 443
+      nodePort: 0
+---
+kind: Endpoints
+apiVersion: v1
+metadata:
+  name: commits-to
+  namespace: traefik-staging
+subsets:
+- addresses:
+  - ip: 10.17.12.208
+  ports:
+  - port: 443
+    name: k8s-https


### PR DESCRIPTION
This one is for production

(after #83)

Set up traefik-proxy that provides passthrough TLS for traefik-outer on the production cluster